### PR TITLE
Add Bun CI, Dependabot, dependency review, tests, and exports

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: bun
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      bun-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(actions)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { formatTransactionDetails, normalize } from "./index";
+
+describe("normalize", () => {
+  it("escapes Telegram MarkdownV2 characters and removes source markers", () => {
+    const input = "Amount [100]_! from #shop.【12:3†source】";
+    const output = normalize(input);
+
+    expect(output).toBe("Amount \\[100\\]\\_\\! from \\#shop\\.");
+  });
+});
+
+describe("formatTransactionDetails", () => {
+  it("returns a transaction error message when error exists", () => {
+    expect(formatTransactionDetails({ error: "Invalid payload" })).toBe(
+      "Transaction error: Invalid payload"
+    );
+  });
+
+  it("falls back to N/A when fields are missing", () => {
+    const result = formatTransactionDetails({ message: "Paid 100k" });
+
+    expect(result).toContain("Paid 100k");
+    expect(result).toContain("*Từ:* N/A");
+    expect(result).toContain("*Ngày:* N/A");
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -29,7 +29,7 @@ app.use(logger())
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
-const normalize = (text: string) =>
+export const normalize = (text: string) =>
     text.replace(/[_\[\]~`>#\+\-=|{}.!]/g, '\\$&').replace(/【\d+:\d+†source】/g, '');
 
 /**
@@ -42,7 +42,7 @@ const normalize = (text: string) =>
  * @param {string} [details.datetime="N/A"] - Datetime of the transaction.
  * @returns {string} Formatted string with transaction details or error message.
  */
-const formatTransactionDetails = (details: any) =>
+export const formatTransactionDetails = (details: any) =>
     details.error
         ? `Transaction error: ${details.error}`
         : `💳 *Có giao dịch thẻ mới nè*\n\n${details.message}\n\n*Từ:* ${details.bank_name || "N/A"}\n*Ngày:* ${details.datetime || "N/A"}\n------------------`;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
     "start": "wrangler dev",
-    "tail": "wrangler tail"
+    "tail": "wrangler tail",
+    "test": "bun test"
   },
   "devDependencies": {
     "wrangler": "^3.114.2"


### PR DESCRIPTION
### Motivation

- Add automated CI and dependency automation to ensure dependencies and tests run on each PR and push.
- Make utility functions available for testing and reuse by exporting them from the module.
- Add a dependency review workflow to surface dependency changes in PRs.

### Description

- Add `.github/dependabot.yml` to enable weekly Dependabot updates for `bun` and `github-actions` with grouped updates and commit-message prefixes. 
- Add `.github/workflows/ci.yml` to run CI on `push` and `pull_request`, which checks out code, sets up Bun with `oven-sh/setup-bun@v2`, installs with `bun install --frozen-lockfile`, and runs `bun test`.
- Add `.github/workflows/dependency-review.yml` to enable the `actions/dependency-review-action@v4` on PRs.
- Export `normalize` and `formatTransactionDetails` in `index.ts` so they can be tested and reused, and keep the existing normalization and formatting logic intact.
- Add `index.test.ts` with unit tests for `normalize` and `formatTransactionDetails` and add a `test` script to `package.json` mapping to `bun test`.

### Testing

- Ran `bun test`, which executed the new `index.test.ts` test suite that covers `normalize` and `formatTransactionDetails`, and the tests passed. 
- CI workflow will run `bun install --frozen-lockfile` followed by `bun test` on `push`/PR as configured in `.github/workflows/ci.yml`.
- Dependency review action is configured to run on PRs using `actions/dependency-review-action@v4` to fail fast on risky dependency changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c62f9b2ecc832e978c510314c446e6)