### PR TITLE
Upgrade configurable OpenAI models to use gpt-5.4-mini defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Since the data is stored in a personal vector database, you can make queries by 
 ## Prerequisite
 
 * A domain hosted on Cloudflare, and don't have any email related DNS records: https://developers.cloudflare.com/email-routing/get-started/enable-email-routing/
-* A paid (tier 1 and up) OpenAI account so you can use their `gpt-4o-mini` model: https://platform.openai.com/docs/guides/rate-limits/usage-tiers
+* A paid OpenAI account so you can use the configured OpenAI models: https://platform.openai.com/docs/guides/rate-limits/usage-tiers
 * A Telegram bot to receive notification and send the queries: https://core.telegram.org/bots/tutorial 
 
 ## Setup
@@ -64,7 +64,10 @@ The application requires the following environment variables:
 | `OPENAI_PROCESS_EMAIL_SYSTEM_PROMPT`    | System message to use for email processing in OpenAI.                    | Yes      | -       |
 | `OPENAI_PROCESS_EMAIL_USER_PROMPT`      | User prompt template for email processing.                               | Yes      | -       |
 | `OPENAI_ASSISTANT_SCHEDULED_PROMPT` | User prompt for daily transaction summary | Yes | - |
-| `OPENAI_PROCESS_EMAIL_MODEL`     | The model used by OpenAI for email processing.                           | Yes      | -       |
+| `OPENAI_PROCESS_EMAIL_MODEL`     | The model used by OpenAI for email/manual transaction processing.         | Yes      | `gpt-5.4-mini` |
+| `OPENAI_OCR_MODEL`               | The vision model used to extract receipt text from Telegram images.       | No       | `gpt-5.4-mini` |
+| `OPENAI_ASSISTANT_MODEL`         | The model override used for assistant question/report runs.               | No       | `gpt-5.4-mini` |
+| `OPENAI_ASSISTANT_ROUTER_MODEL`  | The model used to route Telegram messages to assistant functions.         | No       | `gpt-5.4-mini` |
 | `OPENAI_ASSISTANT_VECTORSTORE_ID`| The vector store identifier for storing processed data in OpenAI.        | Yes      | -       |
 | `OPENAI_ASSISTANT_ID`            | Assistant ID for OpenAI's thread execution.                              | Yes      | -       |
 

--- a/index.ts
+++ b/index.ts
@@ -18,11 +18,19 @@ type Environment = {
     readonly OPENAI_PROCESS_EMAIL_SYSTEM_PROMPT: string;
     readonly OPENAI_PROCESS_EMAIL_USER_PROMPT: string;
     readonly OPENAI_PROCESS_EMAIL_MODEL: string;
+    readonly OPENAI_OCR_MODEL?: string;
+    readonly OPENAI_ASSISTANT_MODEL?: string;
+    readonly OPENAI_ASSISTANT_ROUTER_MODEL?: string;
 
     readonly OPENAI_ASSISTANT_VECTORSTORE_ID: string;
     readonly OPENAI_ASSISTANT_ID: string;
     readonly OPENAI_ASSISTANT_SCHEDULED_PROMPT: string;
 };
+
+const DEFAULT_PROCESS_EMAIL_MODEL = "gpt-5.4-mini";
+const DEFAULT_OCR_MODEL = "gpt-5.4-mini";
+const DEFAULT_ASSISTANT_MODEL = "gpt-5.4-mini";
+const DEFAULT_ASSISTANT_ROUTER_MODEL = "gpt-5.4-mini";
 
 const app = new Hono<{ Bindings: Environment }>();
 app.use(logger())
@@ -140,6 +148,7 @@ const createAndProcessScheduledReport = async (env: Environment, reportType: 'ng
     });
     const run = await openai.beta.threads.createAndRun({
         assistant_id: env.OPENAI_ASSISTANT_ID,
+        model: env.OPENAI_ASSISTANT_MODEL || DEFAULT_ASSISTANT_MODEL,
         thread: { messages: [{ role: "user", content: prompt }] },
     });
 
@@ -169,6 +178,7 @@ const assistantQuestion = async (c, message) => {
 
     const run = await openai.beta.threads.createAndRun({
         assistant_id: c.env.OPENAI_ASSISTANT_ID,
+        model: c.env.OPENAI_ASSISTANT_MODEL || DEFAULT_ASSISTANT_MODEL,
         thread: { messages: [{ role: "user", content: message.text }] },
     });
 
@@ -226,7 +236,7 @@ const imageOcr = async (message, c) => {
     });
 
     const response = await openai.responses.create({
-        model: "gpt-4o-mini",
+        model: c.env.OPENAI_OCR_MODEL || DEFAULT_OCR_MODEL,
         input: [
             {
                 role: "user",
@@ -359,7 +369,7 @@ app.post('/assistant', async (c) => {
 
     console.log("🔫 /assistant/OpenAiResponse request:", message.text);
     const response = await openai.responses.create({
-        model: "gpt-4o",
+        model: c.env.OPENAI_ASSISTANT_ROUTER_MODEL || DEFAULT_ASSISTANT_ROUTER_MODEL,
         input: [
             {
                 role: "user",
@@ -488,7 +498,7 @@ const processTransaction = async (emailData: string, env: Environment) => {
             { role: "system", content: env.OPENAI_PROCESS_EMAIL_SYSTEM_PROMPT },
             { role: "user", content: `${env.OPENAI_PROCESS_EMAIL_USER_PROMPT}\n\n${emailData}` },
         ],
-        model: env.OPENAI_PROCESS_EMAIL_MODEL,
+        model: env.OPENAI_PROCESS_EMAIL_MODEL || DEFAULT_PROCESS_EMAIL_MODEL,
         store: false,
     });
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,7 +12,10 @@ enabled = true
 head_sampling_rate = 1
 
 [vars]
-OPENAI_PROCESS_EMAIL_MODEL = "gpt-4o-mini"
+OPENAI_PROCESS_EMAIL_MODEL = "gpt-5.4-mini"
+OPENAI_OCR_MODEL = "gpt-5.4-mini"
+OPENAI_ASSISTANT_MODEL = "gpt-5.4-mini"
+OPENAI_ASSISTANT_ROUTER_MODEL = "gpt-5.4-mini"
 
 OPENAI_PROCESS_EMAIL_SYSTEM_PROMPT = """
 You act like an personal accountant, extracts email transaction details and summary them in JSON plain format, not markdown, not HTML, just plain JSON like below. No yapping.


### PR DESCRIPTION
### Motivation
- Remove hardcoded OpenAI model names and make the OCR, assistant, router and email-processing models configurable so models can be upgraded without redistributing code.
- Provide sensible default fallbacks to a newer model family (`gpt-5.4-mini`) to modernize processing behavior.

### Description
- Added optional environment bindings `OPENAI_OCR_MODEL`, `OPENAI_ASSISTANT_MODEL`, and `OPENAI_ASSISTANT_ROUTER_MODEL`, and added `DEFAULT_*` fallbacks in `index.ts` so runtime chooses `env.*` or the default model.
- Switched calls that previously used hardcoded models to use the new config or defaults: OCR (`responses.create`), assistant routing (`responses.create`), scheduled/question threads (`beta.threads.createAndRun`), and email/manual processing (`chat.completions.create`).
- Updated `wrangler.toml` to set default model vars to `gpt-5.4-mini` and documented the new environment variables and defaults in `README.md`.

### Testing
- Ran unit tests with `bun test`, which passed (`3 pass`, `0 fail`).
- Ran `bunx tsc --noEmit`, which exited with TypeScript usage output because there is no `tsconfig.json`/input files in this repo (reported as a tooling warning).
- Performed a dry-run deployment with `bunx wrangler deploy --dry-run`, which succeeded and showed the new environment bindings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36aa2f0f18832e8deb89cb602c3375)