### PR TITLE
Harden CI workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- Limit the GitHub Actions workflow token to least privilege to address the CodeQL `actions/missing-workflow-permissions` warning and document required permissions for the CI workflow.

### Description
- Add a root-level `permissions` block to `.github/workflows/ci.yml` with `contents: read` to restrict the workflow token to read-only repository contents access.

### Testing
- Ran `bun test` (28 passed, 0 failed), `git diff --check` (no issues), and `npx gitnexus detect_changes` to verify impact, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38e4375ef8832ebc2b8eab43dca5a7)