### PR TITLE
Fix Telegram markdown backslash escaping

### DIFF
--- a/services/telegram.ts
+++ b/services/telegram.ts
@@ -2,10 +2,10 @@ import { Telegraf } from 'telegraf';
 import type { Environment } from '../types';
 
 export const normalize = (text: string) =>
-    text.replace(/【\d+:\d+†source】/g, '').replace(/[_\[\]\(\)~`>#\+\-=|{}.!]/g, '\\$&');
+    text.replace(/【\d+:\d+†source】/g, '').replace(/[\\_\[\]\(\)~`>#\+\-=|{}.!]/g, '\\$&');
 
 export const stripTelegramMarkdown = (text: string) =>
-    text.replace(/【\d+:\d+†source】/g, '').replace(/[\*_\[\]\(\)~`>#\+\-=|{}.!]/g, '');
+    text.replace(/【\d+:\d+†source】/g, '').replace(/[\\\*_\[\]\(\)~`>#\+\-=|{}.!]/g, '');
 
 /**
  * Formats transaction details into a readable string for Telegram notification.

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -105,6 +105,10 @@ describe("normalize", () => {
     expect(normalize("Paid (AUD)")).toBe("Paid \\(AUD\\)");
   });
 
+  it("escapes backslashes before escaping Telegram MarkdownV2 characters", () => {
+    expect(normalize(String.raw`C:\Transactions\[June]`)).toBe(String.raw`C:\\Transactions\\\[June\]`);
+  });
+
   it("preserves single-asterisk Telegram MarkdownV2 bold markers", () => {
     expect(normalize("*Tổng cộng:* 100 AUD")).toBe("*Tổng cộng:* 100 AUD");
   });
@@ -113,6 +117,10 @@ describe("normalize", () => {
     expect(stripTelegramMarkdown("*Tổng cộng:* 100 AUD (ước tính).【12:3†source】")).toBe(
       "Tổng cộng: 100 AUD ước tính"
     );
+  });
+
+  it("strips backslashes for the plain-text fallback", () => {
+    expect(stripTelegramMarkdown(String.raw`C:\Transactions\[June]`)).toBe("C:TransactionsJune");
   });
 });
 


### PR DESCRIPTION
### Motivation
- Resolve a CodeQL warning about incomplete sanitization by ensuring backslashes are handled when escaping Telegram MarkdownV2 metacharacters. 
- Prevent malformed MarkdownV2 payloads that can break delivery and require fallback sends. 

### Description
- Update `services/telegram.ts` `normalize` to escape backslashes before other MarkdownV2 characters by adding `\\` to the regex character class. 
- Update `services/telegram.ts` `stripTelegramMarkdown` to remove backslashes in the plain-text fallback by including `\\` in the regex. 
- Add regression tests in `tests/index.test.ts` to verify backslash escaping in `normalize` and backslash stripping in `stripTelegramMarkdown`.
- Attempted to run GitNexus impact/detect analysis per repository guidance but the CLI produced only npm warnings and no usable analysis output in this environment. 

### Testing
- Ran unit tests with `bun test`, all tests passed (30 passed, 0 failed). 
- Attempted `npx gitnexus`/detect_changes/impact commands for blast-radius detection but the CLI returned only npm warnings/no analysis output and did not produce a usable impact report in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38e4280328832eaa03c8474a3400c9)