### PR TITLE
Format VND amounts before sending Telegram messages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import { dailyReport, handleAssistantRequest, monthlyReport, weeklyReport } from
 import { email as processEmail } from './handlers/transactions';
 import type { Environment } from './types';
 
-export { buildMessageWithReplyContext, formatTransactionDetails, normalize, stripTelegramMarkdown } from './services/telegram';
+export { buildMessageWithReplyContext, formatCurrencyAmounts, formatTransactionDetails, normalize, stripTelegramMarkdown } from './services/telegram';
 
 const app = new Hono<{ Bindings: Environment }>();
 app.use('*', secureHeaders());

--- a/services/telegram.ts
+++ b/services/telegram.ts
@@ -1,6 +1,23 @@
 import { Telegraf } from 'telegraf';
 import type { Environment } from '../types';
 
+const formatVietnameseNumber = (value: string) => {
+    const normalizedValue = value.replace(/\./g, '').replace(',', '.');
+    const parsedValue = Number(normalizedValue);
+
+    if (!Number.isFinite(parsedValue)) return value;
+
+    return new Intl.NumberFormat('vi-VN', {
+        maximumFractionDigits: Number.isInteger(parsedValue) ? 0 : 2,
+    }).format(parsedValue);
+};
+
+export const formatCurrencyAmounts = (text: string) =>
+    text.replace(/(?<![\d.,])([+-]?\d{1,15}(?:[.,]\d{1,3})?)\s*(VND|VNĐ)(?=$|[^\p{L}\p{N}_])/giu, (_match, amount: string) => {
+        const formattedAmount = formatVietnameseNumber(amount);
+        return `${formattedAmount} VNĐ`;
+    });
+
 export const normalize = (text: string) =>
     text.replace(/【\d+:\d+†source】/g, '').replace(/[\\_\[\]\(\)~`>#\+\-=|{}.!]/g, '\\$&');
 
@@ -54,13 +71,14 @@ export const buildMessageWithReplyContext = (message, fallbackText?: string) => 
  */
 export const sendTelegramMessage = async (env: Environment, message: string, options = {}) => {
     const bot = new Telegraf(env.TELEGRAM_BOT_TOKEN);
+    const formattedMessage = formatCurrencyAmounts(message);
 
     try {
-        await bot.telegram.sendMessage(env.TELEGRAM_CHAT_ID, normalize(message), { parse_mode: "MarkdownV2", ...options });
+        await bot.telegram.sendMessage(env.TELEGRAM_CHAT_ID, normalize(formattedMessage), { parse_mode: "MarkdownV2", ...options });
         console.info("🔫 Telegram response sent successfully");
     } catch (error) {
         console.warn("⚠️ Telegram MarkdownV2 response failed, retrying as plain text", error);
-        await bot.telegram.sendMessage(env.TELEGRAM_CHAT_ID, stripTelegramMarkdown(message), options);
+        await bot.telegram.sendMessage(env.TELEGRAM_CHAT_ID, formatCurrencyAmounts(stripTelegramMarkdown(formattedMessage)), options);
         console.info("🔫 Telegram plain-text fallback response sent successfully");
     }
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -40,6 +40,7 @@ mock.module("postal-mime", () => ({
 const {
   buildMessageWithReplyContext,
   default: worker,
+  formatCurrencyAmounts,
   formatTransactionDetails,
   normalize,
   stripTelegramMarkdown,
@@ -121,6 +122,21 @@ describe("normalize", () => {
 
   it("strips backslashes for the plain-text fallback", () => {
     expect(stripTelegramMarkdown(String.raw`C:\Transactions\[June]`)).toBe("C:TransactionsJune");
+  });
+});
+
+
+describe("formatCurrencyAmounts", () => {
+  it("formats ungrouped VND amounts with Vietnamese thousands separators", () => {
+    expect(formatCurrencyAmounts("21:23 — 385934 VND — POS; Tổng cộng: 439934 VNĐ")).toBe(
+      "21:23 — 385.934 VNĐ — POS; Tổng cộng: 439.934 VNĐ"
+    );
+  });
+
+  it("keeps already grouped VND amounts stable", () => {
+    expect(formatCurrencyAmounts("Bạn đã tiêu 120.000 VNĐ và 54.000 VND")).toBe(
+      "Bạn đã tiêu 120.000 VNĐ và 54.000 VNĐ"
+    );
   });
 });
 
@@ -561,7 +577,7 @@ describe("sendTelegramMessage", () => {
         throw new Error("Markdown rejected");
       })
       .mockImplementationOnce(async () => undefined);
-    openAiResponses = [{ output: [] }, { output_text: "*Tổng cộng:* 100 AUD (ước tính)." }];
+    openAiResponses = [{ output: [] }, { output_text: "*Tổng cộng:* 439934 VND (ước tính)." }];
 
     const response = await worker.fetch(
       new Request("https://worker.example/assistant", {
@@ -580,7 +596,7 @@ describe("sendTelegramMessage", () => {
 
     expect(await response.text()).toBe("Success");
     expect(sendMessageMock).toHaveBeenCalledTimes(2);
-    expect(sendMessageMock.mock.calls[0][1]).toBe("*Tổng cộng:* 100 AUD \\(ước tính\\)\\.");
-    expect(sendMessageMock.mock.calls[1][1]).toBe("Tổng cộng: 100 AUD ước tính");
+    expect(sendMessageMock.mock.calls[0][1]).toBe("*Tổng cộng:* 439\\.934 VNĐ \\(ước tính\\)\\.");
+    expect(sendMessageMock.mock.calls[1][1]).toBe("Tổng cộng: 439.934 VNĐ ước tính");
   });
 });


### PR DESCRIPTION
### Motivation
- Replies sometimes contained raw/unformatted VND values which break readability and inconsistent presentation across Markdown and plain-text fallback paths.
- Ensure all outgoing Telegram messages always render Vietnamese currency with thousands separators so amounts like `385934 VND` become `385.934 VNĐ`.

### Description
- Added `formatVietnameseNumber` and `formatCurrencyAmounts` in `services/telegram.ts` to deterministically format VND/VNĐ amounts using `Intl.NumberFormat` for `vi-VN` style.
- Applied `formatCurrencyAmounts` before both the MarkdownV2 `sendMessage` path and the plain-text fallback so formatting is preserved even when Markdown delivery fails.
- Re-exported `formatCurrencyAmounts` from `index.ts` and added unit tests in `tests/index.test.ts` that cover ungrouped VND, already-grouped VND, and the Markdown fallback behavior.
- Kept existing normalization and Markdown-escaping behavior intact by calling `normalize` / `stripTelegramMarkdown` on the formatted text.

### Testing
- Ran the test suite with `bun test` and all tests passed after the change, including the new `formatCurrencyAmounts` specs.
- Verified end-to-end behaviors exercised by tests: assistant reply formatting, manual transaction flow, OCR/image flows, scheduled reports, and Markdown fallback messaging all remained green.
- Attempted to run GitNexus impact/detect checks (`npx gitnexus` / `detect_changes`) but the MCP CLI/index was not available in this environment, so a manual call-site inspection was used and risk was assessed as low-to-medium because changes are output-only formatting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f654d00c832e827f49829ceacb79)