### PR TITLE
Convert foreign currency amounts to VND and normalize VND formatting

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import { dailyReport, handleAssistantRequest, monthlyReport, weeklyReport } from
 import { email as processEmail } from './handlers/transactions';
 import type { Environment } from './types';
 
-export { buildMessageWithReplyContext, formatCurrencyAmounts, formatTransactionDetails, normalize, stripTelegramMarkdown } from './services/telegram';
+export { buildMessageWithReplyContext, convertCurrencyAmountsToVnd, formatCurrencyAmounts, formatTransactionDetails, normalize, stripTelegramMarkdown } from './services/telegram';
 
 const app = new Hono<{ Bindings: Environment }>();
 app.use('*', secureHeaders());

--- a/services/telegram.ts
+++ b/services/telegram.ts
@@ -2,7 +2,13 @@ import { Telegraf } from 'telegraf';
 import type { Environment } from '../types';
 
 const formatVietnameseNumber = (value: string) => {
-    const normalizedValue = value.replace(/\./g, '').replace(',', '.');
+    const separator = value.includes(',') ? ',' : value.includes('.') ? '.' : '';
+    const separatorIndex = separator ? value.lastIndexOf(separator) : -1;
+    const digitsAfterSeparator = separatorIndex > -1 ? value.length - separatorIndex - 1 : 0;
+    const isThousandsSeparator = separator && digitsAfterSeparator === 3;
+    const normalizedValue = isThousandsSeparator
+        ? value.replace(new RegExp(`\\${separator}`, 'g'), '')
+        : value.replace(/\./g, '').replace(',', '.');
     const parsedValue = Number(normalizedValue);
 
     if (!Number.isFinite(parsedValue)) return value;
@@ -12,11 +18,84 @@ const formatVietnameseNumber = (value: string) => {
     }).format(parsedValue);
 };
 
+const parseCurrencyAmount = (value: string) => {
+    const normalizedValue = value.trim().replace(/\s/g, '');
+    const lastComma = normalizedValue.lastIndexOf(',');
+    const lastDot = normalizedValue.lastIndexOf('.');
+
+    if (lastComma > -1 && lastDot > -1) {
+        const decimalSeparator = lastComma > lastDot ? ',' : '.';
+        const thousandsSeparator = decimalSeparator === ',' ? '.' : ',';
+        return Number(normalizedValue.replace(new RegExp(`\\${thousandsSeparator}`, 'g'), '').replace(decimalSeparator, '.'));
+    }
+
+    const separator = lastComma > -1 ? ',' : lastDot > -1 ? '.' : '';
+    if (!separator) return Number(normalizedValue);
+
+    const separatorIndex = normalizedValue.lastIndexOf(separator);
+    const digitsAfterSeparator = normalizedValue.length - separatorIndex - 1;
+    const isDecimalSeparator = digitsAfterSeparator > 0 && digitsAfterSeparator <= 2;
+
+    return Number(isDecimalSeparator
+        ? normalizedValue.replace(separator, '.')
+        : normalizedValue.replace(new RegExp(`\\${separator}`, 'g'), ''));
+};
+
+const formatDong = (value: number) => `${new Intl.NumberFormat('vi-VN', { maximumFractionDigits: 0 }).format(Math.round(value))}đ`;
+
+const getExchangeRateToVnd = async (currency: string) => {
+    const normalizedCurrency = currency.toLowerCase();
+    const urls = [
+        `https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/${normalizedCurrency}.min.json`,
+        `https://latest.currency-api.pages.dev/v1/currencies/${normalizedCurrency}.min.json`,
+    ];
+
+    for (const url of urls) {
+        try {
+            const response = await fetch(url);
+            if (!response.ok) continue;
+
+            const data = await response.json() as Record<string, Record<string, number>>;
+            const rate = data[normalizedCurrency]?.vnd;
+            if (Number.isFinite(rate)) return rate;
+        } catch (error) {
+            console.warn(`⚠️ Failed to fetch ${currency.toUpperCase()} to VND exchange rate from ${url}`, error);
+        }
+    }
+
+    return null;
+};
+
 export const formatCurrencyAmounts = (text: string) =>
-    text.replace(/(?<![\d.,])([+-]?\d{1,15}(?:[.,]\d{1,3})?)\s*(VND|VNĐ)(?=$|[^\p{L}\p{N}_])/giu, (_match, amount: string) => {
+    text.replace(/(?<![\d.,])([+-]?\d{1,15}(?:[.,]\d{1,3})?)\s*(VND|VNĐ|đ)(?=$|[^\p{L}\p{N}_])/giu, (_match, amount: string) => {
         const formattedAmount = formatVietnameseNumber(amount);
-        return `${formattedAmount} VNĐ`;
+        return `${formattedAmount}đ`;
     });
+
+export const convertCurrencyAmountsToVnd = async (text: string) => {
+    const formattedText = formatCurrencyAmounts(text);
+    const currencyMatches = [...formattedText.matchAll(/(?<![\d.,])([+-]?\d{1,15}(?:[.,]\d{1,3})?)\s*([A-Z]{3})(?!\s*\()(?=$|[^\p{L}\p{N}_])/giu)]
+        .filter((match) => !['VND', 'VNĐ'].includes(match[2].toUpperCase()));
+
+    let convertedText = formattedText;
+    const rates = new Map<string, number | null>();
+
+    for (const match of currencyMatches) {
+        const [matchedText, amount, currency] = match;
+        const normalizedCurrency = currency.toUpperCase();
+        if (!rates.has(normalizedCurrency)) {
+            rates.set(normalizedCurrency, await getExchangeRateToVnd(normalizedCurrency));
+        }
+
+        const rate = rates.get(normalizedCurrency);
+        const parsedAmount = parseCurrencyAmount(amount);
+        if (!rate || !Number.isFinite(parsedAmount)) continue;
+
+        convertedText = convertedText.replace(matchedText, `${matchedText} (${formatDong(parsedAmount * rate)})`);
+    }
+
+    return convertedText;
+};
 
 export const normalize = (text: string) =>
     text.replace(/【\d+:\d+†source】/g, '').replace(/[\\_\[\]\(\)~`>#\+\-=|{}.!]/g, '\\$&');
@@ -71,7 +150,7 @@ export const buildMessageWithReplyContext = (message, fallbackText?: string) => 
  */
 export const sendTelegramMessage = async (env: Environment, message: string, options = {}) => {
     const bot = new Telegraf(env.TELEGRAM_BOT_TOKEN);
-    const formattedMessage = formatCurrencyAmounts(message);
+    const formattedMessage = await convertCurrencyAmountsToVnd(message);
 
     try {
         await bot.telegram.sendMessage(env.TELEGRAM_CHAT_ID, normalize(formattedMessage), { parse_mode: "MarkdownV2", ...options });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -40,6 +40,7 @@ mock.module("postal-mime", () => ({
 const {
   buildMessageWithReplyContext,
   default: worker,
+  convertCurrencyAmountsToVnd,
   formatCurrencyAmounts,
   formatTransactionDetails,
   normalize,
@@ -129,14 +130,39 @@ describe("normalize", () => {
 describe("formatCurrencyAmounts", () => {
   it("formats ungrouped VND amounts with Vietnamese thousands separators", () => {
     expect(formatCurrencyAmounts("21:23 — 385934 VND — POS; Tổng cộng: 439934 VNĐ")).toBe(
-      "21:23 — 385.934 VNĐ — POS; Tổng cộng: 439.934 VNĐ"
+      "21:23 — 385.934đ — POS; Tổng cộng: 439.934đ"
     );
   });
 
   it("keeps already grouped VND amounts stable", () => {
     expect(formatCurrencyAmounts("Bạn đã tiêu 120.000 VNĐ và 54.000 VND")).toBe(
-      "Bạn đã tiêu 120.000 VNĐ và 54.000 VNĐ"
+      "Bạn đã tiêu 120.000đ và 54.000đ"
     );
+  });
+
+  it("uses đ for existing VND shorthand amounts", () => {
+    expect(formatCurrencyAmounts("Đóng tiền khám bệnh cho Coca: 540,000đ")).toBe(
+      "Đóng tiền khám bệnh cho Coca: 540.000đ"
+    );
+  });
+});
+
+describe("convertCurrencyAmountsToVnd", () => {
+  it("adds VND conversions for foreign currency amounts", async () => {
+    fetchHandler = async (input) => {
+      expect(String(input)).toBe("https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/usd.min.json");
+      return Response.json({ usd: { vnd: 25000 } });
+    };
+
+    await expect(convertCurrencyAmountsToVnd("- 18/12/2025 — 8,99 USD cho dịch vụ máy chủ ảo Rackspace.")).resolves.toBe(
+      "- 18/12/2025 — 8,99 USD (224.750đ) cho dịch vụ máy chủ ảo Rackspace."
+    );
+  });
+
+  it("keeps foreign currency text unchanged when exchange lookup fails", async () => {
+    fetchHandler = async () => new Response(null, { status: 503 });
+
+    await expect(convertCurrencyAmountsToVnd("Paid 12 USD")).resolves.toBe("Paid 12 USD");
   });
 });
 
@@ -279,7 +305,7 @@ describe("handleAssistantRequest", () => {
     expect(openAiResponsesCreate.mock.calls[1][0].instructions).toContain("Format for Telegram.");
     expect(sendMessageMock).toHaveBeenCalledWith(
       env.TELEGRAM_CHAT_ID,
-      expect.stringContaining("Bạn đã tiêu 100\\.000 VNĐ hôm nay\\."),
+      expect.stringContaining("Bạn đã tiêu 100\\.000đ hôm nay\\."),
       expect.objectContaining({ reply_to_message_id: 77, parse_mode: "MarkdownV2" })
     );
   });
@@ -596,7 +622,7 @@ describe("sendTelegramMessage", () => {
 
     expect(await response.text()).toBe("Success");
     expect(sendMessageMock).toHaveBeenCalledTimes(2);
-    expect(sendMessageMock.mock.calls[0][1]).toBe("*Tổng cộng:* 439\\.934 VNĐ \\(ước tính\\)\\.");
-    expect(sendMessageMock.mock.calls[1][1]).toBe("Tổng cộng: 439.934 VNĐ ước tính");
+    expect(sendMessageMock.mock.calls[0][1]).toBe("*Tổng cộng:* 439\\.934đ \\(ước tính\\)\\.");
+    expect(sendMessageMock.mock.calls[1][1]).toBe("Tổng cộng: 439.934đ ước tính");
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure Telegram notifications show VND equivalents for non-VNĐ amounts and present Vietnamese amounts in a consistent, compact form using the `đ` suffix.
- Provide a reliable exchange-rate lookup with fallback so foreign-currency mentions (e.g. `USD`) are augmented with a clear VNĐ conversion.

### Description
- Added parsing and formatting helpers in `services/telegram.ts`: `parseCurrencyAmount`, `formatDong`, and `getExchangeRateToVnd` that query the fawazahmed0 currency API via jsDelivr with a Pages fallback.
- Introduced `convertCurrencyAmountsToVnd` which normalizes VND/VNĐ/`đ` amounts and appends `(xxxđ)` conversions for three-letter foreign currencies, and re-exported it from `index.ts`.
- Updated `formatCurrencyAmounts` to normalize existing VND notations to use Vietnamese thousands separators and the shorter `đ` suffix, and changed `sendTelegramMessage` to run the conversion before Markdown/plain-text handling.
- Updated unit tests in `tests/index.test.ts` to cover `đ` formatting, currency conversion, exchange lookup fallback behavior, and adjusted Telegram formatting expectations.

### Testing
- Ran the test suite with `bun test`, and all tests passed (`38` tests, `0` failures).
- Unit tests specifically cover formatting of VND shorthand, adding VNĐ conversions for foreign currencies, and fallback when exchange lookup fails (all passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f8cee424832e83309edc9cca1177)